### PR TITLE
Show tenure at company

### DIFF
--- a/people/models.py
+++ b/people/models.py
@@ -53,6 +53,23 @@ class Teammate(MPTTModel):
         return datetime.date(month=self.bday_month, day=self.bday_day, year=1)
 
     @property
+    def tenure(self):
+        if not self.start_date:
+            return None
+
+        return datetime.date.today() - self.start_date
+
+    @property
+    def tenure_percentile(self):
+        if not self.start_date:
+            return None
+
+        active_teammates = Teammate.objects.filter(is_hidden=False, start_date__isnull=False)
+        more_tenured_teammates = active_teammates.filter(start_date__lt=self.start_date)
+
+        return more_tenured_teammates.count() / active_teammates.count()
+
+    @property
     def main_team(self):
         try:
             return Team.objects.get(name=self.team_name)

--- a/people/templates/people/employee.html
+++ b/people/templates/people/employee.html
@@ -80,6 +80,14 @@
               {{ teammate.start_date }}
             </div>
             {% endif %}
+            {% if teammate.tenure %}
+            <div class="w-40-ns tr-ns pr4 f2 f5-ns lh-title mt4 mt2-ns mb1 mb0-ns silver">
+              DIP
+            </div>
+            <div class="w-60-ns f1 lh-title f5-ns truncate mt2-ns">
+              {{ teammate.tenure.days }} days (top {{teammate.tenure_percentile | percentage:0}})
+            </div>
+            {% endif %}
             {% if teammate.bday %}
             <div class="w-40-ns tr-ns pr4 f2 f5-ns lh-title mt4 mt2-ns mb1 mb0-ns silver">
               Birthday

--- a/people/templatetags/people_extras.py
+++ b/people/templatetags/people_extras.py
@@ -14,3 +14,7 @@ def highlight(value, search_term, autoescape=True, prepend_at_sign=True):
     return mark_safe(
         value.replace(search_term, "<span class='black fw5'>%s</span>" % search_term)
     )
+
+@register.filter
+def percentage(value, decimals=2):
+    return '{:.{prec}%}'.format(value, prec=decimals)


### PR DESCRIPTION
Thought calling it `DIP` was fun. Not in love with "(top 7%)" as it implies some superiority with tenure, but the brevity is nice for fitting into the UI. Open to other ideas!

| | |
|-|-|
| <img width="323" alt="image 2019-02-27 at 1 10 19 am" src="https://user-images.githubusercontent.com/84566/53480018-28915d80-3a2f-11e9-8d12-e321f52cf2e4.png"> | <img width="328" alt="image 2019-02-27 at 1 09 53 am" src="https://user-images.githubusercontent.com/84566/53480036-30e99880-3a2f-11e9-85a2-ebc6e4970199.png"> |




## Database queries
Seems reasonable. We should probably add an index on `start_date` at some point.
<img width="1223" alt="image 2019-02-27 at 1 17 28 am" src="https://user-images.githubusercontent.com/84566/53479778-a30dad80-3a2e-11e9-9d93-5046ae659911.png">
