### PR TITLE
Ignore invite messages in #props

### DIFF
--- a/people/management/commands/sync_slack_props.py
+++ b/people/management/commands/sync_slack_props.py
@@ -49,6 +49,9 @@ class Command(BaseCommand):
             if msg["ts"] in existing_props_ts:  # we've already saved this in the db
                 continue
 
+            if not self.eligible(msg):
+                continue
+
             mentioned_teammates = [
                 teammates[f"<@{uid}>"]
                 for uid in re.findall(at_mention_pattern, msg["text"])
@@ -67,3 +70,13 @@ class Command(BaseCommand):
             props.save()
 
             props.teammates_to.set(mentioned_teammates)
+
+    @classmethod
+    def eligible(cls, msg):
+        return not cls.is_invite_message(msg)
+
+    @classmethod
+    def is_invite_message(cls, msg):
+        # one or more mentions separated by whitespace
+        invites_pattern = re.compile(r"^(<@(\w+)>\s*)+$")
+        return re.match(invites_pattern, msg['text'].strip()) and not msg.get('files') and not msg.get('attachments')

--- a/people/management/commands/sync_slack_props.py
+++ b/people/management/commands/sync_slack_props.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
 
         teammates = {f"<@{t.slack_uid}>": t for t in Teammate.objects.all()}
 
-        at_mention_pattern = re.compile(r"<@(.*?)>")
+        at_mention_pattern = re.compile(r"<@(\w+)>")
         tz = timezone(settings.TIME_ZONE)
 
         for msg in props_msgs:


### PR DESCRIPTION
Ran this on the whole set of messages and it would have filtered out these:
```
INELIGIBLE!! "@Jack Derrickson" 2019-02-12 11:24:43.019400
INELIGIBLE!! "@Casey Blakely" 2018-12-17 06:56:13.349600
INELIGIBLE!! "@Gabriella Papatzimas" 2018-11-30 06:08:22.026500
INELIGIBLE!! "@Sarah Groh" 2018-11-29 13:49:58.807100
INELIGIBLE!! "@Brandon Gedicks" 2018-11-13 08:29:20.395000
INELIGIBLE!! "@Karen LaVorgna" 2018-11-12 10:43:53.375500
INELIGIBLE!! "@Nikki Russo" 2018-10-29 08:24:52.020100
INELIGIBLE!! "@Mike Schultz" 2018-10-29 06:44:58.019100
INELIGIBLE!! "@Jon Mason" 2018-10-15 14:43:35.000100
INELIGIBLE!! "@Jordan Burke" 2018-10-15 13:38:54.000100
INELIGIBLE!! "@Lindsey Stein" 2018-10-05 16:58:20.000100
INELIGIBLE!! "@Joe Crihfield @Matt Gray " 2018-10-03 14:41:48.000100
INELIGIBLE!! "@Mallory Salisbury" 2018-09-13 15:52:47.000100
INELIGIBLE!! "@Nick Tobiasz" 2018-06-14 14:43:36.000431
INELIGIBLE!! "@Danny Walker" 2018-02-22 13:06:50.000596
INELIGIBLE!! "@Matt Kieffer (Unavailable - Please contact Tara M. or Scott N.) " 2017-06-20 06:01:42.124428
INELIGIBLE!! "@Byron McClurg" 2017-06-19 22:25:12.190198
```

We'll need to drop the `PropsMessage` table and repopulate to fix existing messages.